### PR TITLE
Disable graph auto-resize

### DIFF
--- a/src/onyx_blueprint/ui/graph.cljs
+++ b/src/onyx_blueprint/ui/graph.cljs
@@ -13,7 +13,8 @@
   (let [{:keys [graph-direction graph-selectable]
          :or {graph-direction "UD"
               graph-selectable true}} (:layout/hints props)
-        opts {:nodes {:shape "dot"}
+        opts {:autoResize false
+              :nodes {:shape "dot"}
               :edges {:arrows "to"}
               :layout {:hierarchical {:enabled true
                                       :sortMethod "directed"


### PR DESCRIPTION
This was causing issues in Firefox, as reported by @drewverlee.

Will need to readdress in broader browser-responsiveness pass.